### PR TITLE
run every modeladmin in separate subtest

### DIFF
--- a/test_project/main/tests.py
+++ b/test_project/main/tests.py
@@ -1,10 +1,7 @@
+from django.core.exceptions import FieldError
 from django.test import TestCase
 
-from django_admin_smoke_tests.tests import (
-    AdminSiteSmokeTestMixin,
-    ModelAdminCheckException,
-    for_all_model_admins,
-)
+from django_admin_smoke_tests.tests import AdminSiteSmokeTestMixin
 
 from .admin import ChannelAdmin, FailPostAdmin, ForbiddenPostAdmin, PostAdmin
 from .models import Channel, FailPost
@@ -27,20 +24,33 @@ class FailAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
         )
         super(FailAdminSiteSmokeTest, self).setUp()
 
-    @for_all_model_admins
-    def test_specified_fields(self, model, model_admin):
-        with self.assertRaises(ModelAdminCheckException):
-            super(FailAdminSiteSmokeTest, self).test_specified_fields()
+    def specified_fields_func(self, model, model_admin):
+        if model_admin.__class__ == FailPostAdmin:
+            with self.assertRaisesRegex(
+                AssertionError,
+                "False is not true : nonexistent_field not found on "
+                "<class 'test_project.main.models.FailPost'> \\(main.FailPostAdmin\\)",
+            ):
+                super().specified_fields_func(model, model_admin)
+        else:
+            super().specified_fields_func(model, model_admin)
 
-    @for_all_model_admins
-    def test_changelist_view_search(self, model, model_admin):
-        with self.assertRaises(ModelAdminCheckException):
-            super(FailAdminSiteSmokeTest, self).test_changelist_view_search()
+    def changelist_view_search_func(self, model, model_admin):
+        if model_admin.__class__ == FailPostAdmin:
+            with self.assertRaisesRegex(
+                FieldError,
+                "Cannot resolve keyword 'nonexistent_field' into field. Choices are: author.*",
+            ):
+                super().changelist_view_search_func(model, model_admin)
+        else:
+            super().changelist_view_search_func(model, model_admin)
 
-    @for_all_model_admins
-    def test_changelist_view(self, model, model_admin):
-        with self.assertRaises(ModelAdminCheckException):
-            super(FailAdminSiteSmokeTest, self).test_changelist_view()
+    def changelist_view_func(self, model, model_admin):
+        if model_admin.__class__ == FailPostAdmin:
+            with self.assertRaisesRegex(Exception, ""):
+                super().changelist_view_func(model, model_admin)
+        else:
+            super().changelist_view_func(model, model_admin)
 
 
 class ForbiddenAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):


### PR DESCRIPTION
- introduce get_modeladmins() method for better overridability
- split testing functions to decorated function and actual test run for
 better overriding in tests
- improve tests to check for the actual Exception