### PR TITLE
fix wrong/missing form data being used if a field uses a MultiWidget

### DIFF
--- a/django_admin_smoke_tests/baker_field_generators.py
+++ b/django_admin_smoke_tests/baker_field_generators.py
@@ -1,6 +1,7 @@
 # This file contain model_bakery field genrators for field types that
 # can be found in various Django apps.
 # TODO: this should be moved to the apps where the field defined.
+import os
 import shutil
 from decimal import Decimal
 
@@ -22,6 +23,11 @@ def gen_avatar():
         "./blenderhub/apps/assets/test_files/test.jpg",
         f"{settings.MEDIA_ROOT}/test_image",
     )
+    # Make it compatible with the remove_avatar_images signal handler.
+    try:
+        os.mkdir(f"{settings.MEDIA_ROOT}/resized")
+    except FileExistsError:
+        pass
     return "test_image"
 
 


### PR DESCRIPTION
If a model's field uses a widget that is a subclass of `MultiWidget`, `form_data` does not generate correct data. This is the case for `DateTimeField` for example.

e. g. if there is a field `published = models.DateTimeField()`, `form_data` generates:
```python3
data = {"published": datetime.datetime(2024, 9, 20, 11, 18, 53, 264181, tzinfo=UTC)}
```
and the admin form and the underlying widget receive it as:
```python3
data = {'published': ['2024-09-20 11:18:53.264181+00:00'], ...}
```

However, the default `AdminSplitDateTime` widget expects:
```python3
data = {"published_0": ["2024-09-20"], "published_1": ["11:18:53"], ...}
```

This results in the `AdminSplitDateTime` widget's `value_from_datadict` returning `[None, None]` and thus the admin form setting the model's field `published` to `None`.


Also, fixing this bug makes the `AvatarAdmin` tests not fail silently anymore. On the other hand, they started to fail loudly because of the missing `resized` folder. I fixed that too.


- [x] Requires https://github.com/PetrDlouhy/django-admin-smoke-tests/pull/8 to pass CI.

**edit:** this is no longer required, but some tests will fail silently without it (i.e. `AvatarAdmin`)